### PR TITLE
Fix unique key warnings

### DIFF
--- a/app/equipamentos/data-table.tsx
+++ b/app/equipamentos/data-table.tsx
@@ -429,7 +429,7 @@ export function DataTable({ data, pocMap, urlMap }) {
                 } `}
               >
                 {row.getVisibleCells().map((cell, index) => (
-                  <TableCell key={cell.row}>
+                  <TableCell key={`${row.id}-${index}`}> 
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}

--- a/components/dashboard-cards.tsx
+++ b/components/dashboard-cards.tsx
@@ -17,9 +17,9 @@ async function DashboardCards() {
           <CardDescription>Equipamentos cadastrados</CardDescription>
         </CardHeader>
         <CardContent>
-          {equipamentosCadastrados.map((item) => (
+          {equipamentosCadastrados.map((item, index) => (
             <Info
-              key={item.equipamento_type}
+              key={`${item.equipamento_type}-${index}`}
               info1={item.tipo_count}
               info2={item.equipamento_type}
             />
@@ -31,9 +31,9 @@ async function DashboardCards() {
           <CardDescription>Status dos equipamentos</CardDescription>
         </CardHeader>
         <CardContent>
-          {equipamentosStatus.map((item) => (
+          {equipamentosStatus.map((item, index) => (
             <Info
-              key={item.equipamento_status}
+              key={`${item.equipamento_status}-${index}`}
               info1={item.status_count}
               info2={item.equipamento_status}
             />

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Simple helper to generate a unique identifier
+export function uniqueKey(prefix: string = 'key') {
+  const random = Math.random().toString(36).slice(2)
+  return `${prefix}-${random}`
+}


### PR DESCRIPTION
## Summary
- ensure map keys include an index so they're unique
- generate unique keys for table cells
- add a helper for generating random keys

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c637359508320b87b50e1a428a646